### PR TITLE
Display modal form validation errors; flash success

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,19 @@ Example, in response to this [StackOverflow](https://stackoverflow.com/q/4759319
 of using a Bootstrap modal popup to update multiple records selected in a Flask-Admin batch action.
 
 ![Popup Demo](flask-admin-modal.gif)
+
+## Installation
+
+```bash
+git clone https://github.com/pjcunningham/flask-admin-modal.git
+cd flask-admin-modal
+
+# (optional, create a virtual environment)
+virtualenv venv && source venv/bin/activate
+
+# fetch dependencies; add '--user' if not using a virtualenv
+pip install -r requirements.txt
+
+# launch app w/ optional port number (default: 5000)
+python run.py  # 8080
+```

--- a/templates/admin/model/custom_list.html
+++ b/templates/admin/model/custom_list.html
@@ -12,7 +12,7 @@
           </div>
           <div class="modal-body">
               {% if change_modal %}
-                  {{ lib.render_form(change_form, url, action=url_for('project.update_view')) }}
+                  {{ lib.render_form(change_form, cancel_url=url, action=url_for('project.update_view', url=url)) }}
               {% endif %}
           </div>
         </div><!-- /.modal-content -->

--- a/templates/admin/model/custom_list.html
+++ b/templates/admin/model/custom_list.html
@@ -12,7 +12,7 @@
           </div>
           <div class="modal-body">
               {% if change_modal %}
-                  {{ lib.render_form(change_form, action=url_for('project.update_view', url=url)) }}
+                  {{ lib.render_form(change_form, url, action=url_for('project.update_view')) }}
               {% endif %}
           </div>
         </div><!-- /.modal-content -->


### PR DESCRIPTION
Adds a few minor enhancements, but in particular it handles form validation errors by re-displaying the form (WTForms takes care of the rest).

There's no compelling reason for you to _ever_ merge this PR, but it has solutions to all of the immediate questions I had after looking at your sample code (like how to suppress the JavaScript alert), so if it's closed without merging, at least there will still be a record of it in your repo. <tt>:)</tt>

Thanks for sharing this great example on Stack Overflow in the first place!

—Kevin

![flask-admin-modal-validation-demo](https://user-images.githubusercontent.com/4009681/40087762-16463ad2-5872-11e8-9d6a-e7839362d843.gif)

Other changes:

- suppresses superfluous JavaScript alert before the modal form (you can always cancel the form)
- if successful, displays how many records were modified in a flash message
- adds `cancel_url` keyword argument to Flask-Admin's `lib.render_form` macro such that you get a "Cancel" button in addition to a "Save" button
- allows you to pass a port number to `run.py` (_e.g._, `python run.py 8080`)—since I always seem to have another Flask dev server instance running somewhere